### PR TITLE
Fix workbook uploads with error overlay and layout fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
   <body>
     <header class="toolbar">
       <div class="toolbar-left">
-        <button id="open-workbook-btn" type="button">Open Workbook</button>
-        <button id="fit-btn" type="button">Fit</button>
-        <button id="layout-btn" type="button">Auto layout</button>
-        <button id="expand-1-btn" type="button">Expand 1-hop</button>
-        <button id="expand-2-btn" type="button">Expand 2-hop</button>
-        <button id="hide-isolated-btn" type="button">Hide isolated</button>
+        <button id="openBtn" type="button">Open Workbook</button>
+        <button id="fitBtn" type="button">Fit</button>
+        <button id="layoutBtn" type="button">Auto layout</button>
+        <button id="expand1Btn" type="button">Expand 1-hop</button>
+        <button id="expand2Btn" type="button">Expand 2-hop</button>
+        <button id="hideIsolatedBtn" type="button">Hide isolated</button>
         <details class="dropdown" id="filters-dropdown">
           <summary>Filters</summary>
           <div class="dropdown-menu">
@@ -46,8 +46,8 @@
       <div class="toolbar-right">
         <button id="theme-toggle" type="button" aria-pressed="false">Light</button>
         <form id="search-form" role="search">
-          <label for="search-box" class="visually-hidden">Search nodes</label>
-          <input id="search-box" name="q" type="search" placeholder="Search..." list="node-names" autocomplete="off" />
+          <label for="search" class="visually-hidden">Search nodes</label>
+          <input id="search" name="q" type="search" placeholder="Search..." list="node-names" autocomplete="off" />
           <datalist id="node-names"></datalist>
         </form>
       </div>
@@ -55,8 +55,8 @@
 
     <main class="layout">
       <aside class="sidebar">
-        <section id="dropzone" class="dropzone" aria-label="Workbook drop zone" tabindex="0">
-          <input id="file-input" type="file" accept=".twb,.twbx" hidden />
+        <section id="dropZone" class="dropzone" aria-label="Workbook drop zone" tabindex="0">
+          <input id="fileInput" type="file" accept=".twb,.twbx" hidden />
           <p>Drop a Tableau .twb or .twbx file here<br />or click Open Workbook.</p>
         </section>
         <nav class="tabs" aria-label="Sidebar tabs">
@@ -90,13 +90,15 @@
     </main>
 
     <footer class="status-bar">
-      <span id="status-text">Ready.</span>
+      <span id="status">Ready.</span>
       <span id="footer-info"></span>
     </footer>
 
+    <div id="errOverlay"></div>
+
     <script src="./lib/jszip.min.js"></script>
     <script src="./lib/cytoscape.min.js"></script>
-    <script src="./lib/cytoscape-cose-bilkent.min.js"></script>
+    <script src="./lib/cytoscape-cose-bilkent.min.js"></script> <!-- keep if present -->
     <script src="./app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -309,6 +309,26 @@ main.layout {
   color: var(--color-muted);
 }
 
+#errOverlay {
+  position: fixed;
+  left: 10px;
+  bottom: 10px;
+  max-width: 70vw;
+  background: rgba(200, 0, 0, 0.15);
+  color: #ffdddd;
+  border: 1px solid rgba(255, 0, 0, 0.35);
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 12px;
+  display: none;
+  z-index: 9999;
+}
+
+#errOverlay pre {
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- add an error overlay with global error/rejection handling so runtime failures are visible in the UI
- restore the workbook input and drag-and-drop flows with defensive parsing and .twbx extraction safeguards
- guard the Cytoscape layout plugin and align DOM ids with the updated controls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf461674cc8320b6eab7e7c754f3cd