### PR TITLE
feat: Bloom-style selection and smarter layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
         <button id="openBtn" type="button">Open Workbook</button>
         <button id="fitBtn" type="button">Fit</button>
         <button id="layoutBtn" type="button">Auto layout</button>
-        <button id="expand1Btn" type="button">Expand 1-hop</button>
-        <button id="expand2Btn" type="button">Expand 2-hop</button>
+        <button id="expand1Btn" type="button" title="Show 1-hop neighbors">Expand 1-hop</button>
+        <button id="expand2Btn" type="button" title="Show 2-hop neighbors">Expand 2-hop</button>
         <button id="hideIsolatedBtn" type="button">Hide isolated</button>
         <details class="dropdown" id="filters-dropdown">
           <summary>Filters</summary>

--- a/styles.css
+++ b/styles.css
@@ -190,7 +190,7 @@ main.layout {
 
 .faded {
   opacity: 0.15;
-  transition: opacity 120ms ease;
+  transition: opacity 150ms ease;
 }
 
 .details {


### PR DESCRIPTION
## Summary
- add Bloom-style node focus with localized layout and fade handling for taps and neighbor expansion
- improve initial and auto layout behavior, including large graph seeding and stronger repulsion settings
- polish expand controls with tooltips and smoother fading visuals

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68cf5d4fef1483209427da5f0715ae96