### PR TITLE
Restore 3-pane layout and refit Cytoscape canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ if (typeof window !== 'undefined') {
   window.addEventListener('unhandledrejection', (event) => {
     showError('Unhandled promise rejection:', event.reason);
   });
+  window.addEventListener('resize', () => fitGraph());
 }
 
 let hasBilkent = false;
@@ -436,10 +437,14 @@ function bootGraph() {
 }
 
 function setStatus(text) {
-  const el = document.getElementById('status') || document.getElementById('status-text');
-  if (el) {
+  const targets = [
+    document.getElementById('status'),
+    document.getElementById('status-text'),
+  ].filter(Boolean);
+  if (!targets.length) return;
+  targets.forEach((el) => {
     el.textContent = text;
-  }
+  });
 }
 
 async function handleFile(file) {
@@ -976,6 +981,8 @@ function drawGraph(graph) {
 
   applyFilters({ rerunLayout: false });
 
+  fitGraph();
+
   if (nodeCount) {
     runLayoutWithFit(getGraphLayoutOptions(nodeCount));
   }
@@ -1050,10 +1057,11 @@ function hideIsolated() {
 
 function fitGraph() {
   if (!state.cy) return;
+  const rect = document.getElementById('graph')?.getBoundingClientRect();
+  if (!rect || rect.width < 10 || rect.height < 10) return;
   const elements = state.cy.elements().filter((ele) => ele.style('display') !== 'none');
-  if (elements.length) {
-    state.cy.fit(elements, 100);
-  }
+  if (!elements.length) return;
+  state.cy.fit(elements, 40);
 }
 
 function fitToElements(elements, padding = 80) {

--- a/index.html
+++ b/index.html
@@ -103,8 +103,9 @@
         </section>
       </aside>
 
-      <section class="graph-container graphwrap">
+      <section class="graphwrap">
         <div id="graph"></div>
+        <div id="status" class="status">No workbook loaded.</div>
       </section>
 
       <aside class="details" id="details" aria-live="polite">
@@ -114,7 +115,7 @@
     </main>
 
     <footer class="status-bar">
-      <span id="status">Ready.</span>
+      <span id="status-text">Ready.</span>
       <span id="footer-info"></span>
     </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,6 @@
 :root {
+  --topbar-h: 64px;
+  --footer-h: 36px;
   --gem-bg: #0E0B14;
   --gem-surface: #151827;
   --gem-surface-2: #1b2030;
@@ -86,6 +88,7 @@ header.topbar {
   z-index: 10;
   margin: 16px 16px 12px;
   padding: 14px 18px;
+  min-height: var(--topbar-h);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -240,9 +243,18 @@ summary::-webkit-details-marker {
 main.layout {
   flex: 1;
   display: grid;
-  grid-template-columns: 280px 1fr 360px;
-  gap: 18px;
-  padding: 12px 16px 18px;
+  grid-template-columns: 260px 1fr 340px;
+  grid-template-rows: 1fr;
+  gap: 12px;
+  height: calc(100vh - var(--topbar-h) - var(--footer-h));
+  padding: 8px 10px;
+}
+
+.sidebar,
+.details,
+.graphwrap {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .sidebar,
@@ -251,24 +263,37 @@ main.layout {
   display: flex;
   flex-direction: column;
   gap: 18px;
-  min-height: 0;
+  overflow: auto;
 }
 
-.graph-container {
+.graphwrap {
   position: relative;
-  padding: 12px;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
+  padding: 0;
+  height: 100%;
+  min-height: 540px;
 }
 
 #graph {
-  flex: 1;
-  width: 100%;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
   border-radius: var(--radius-lg);
   border: 1px solid var(--gem-border);
   background: var(--gem-surface-2);
+}
+
+.status {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--gem-border);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(12px);
+  font-size: 0.85rem;
+  color: var(--gem-text);
+  pointer-events: none;
 }
 
 .dropzone {
@@ -389,6 +414,7 @@ main.layout {
   gap: 16px;
   margin: 0 16px 16px;
   padding: 12px 18px;
+  min-height: var(--footer-h);
   font-size: 0.85rem;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02)), var(--gem-surface);
   border: 1px solid var(--gem-border);
@@ -438,30 +464,32 @@ main.layout {
   transition: opacity var(--trans);
 }
 
-@media (max-width: 1200px) {
-  main.layout {
-    grid-template-columns: 240px 1fr;
-    grid-template-areas:
-      'sidebar sidebar'
-      'graph graph'
-      'details details';
-  }
-
-  .sidebar,
-  .graph-container,
-  .details {
-    grid-area: unset;
-  }
-}
-
 @media (max-width: 980px) {
   header.topbar {
     flex-direction: column;
     align-items: flex-start;
   }
+}
 
+@media (max-width: 900px) {
   main.layout {
     grid-template-columns: 1fr;
+    grid-template-rows: auto 60vh auto;
+    height: auto;
+  }
+
+  .graphwrap {
+    order: 1;
+    height: 60vh;
+    min-height: 360px;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+
+  .details {
+    order: 3;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the sidebar/graph/details structure with an inline graph status indicator
- reinstate the fixed three-column grid and responsive stacking with updated height variables
- guard Cytoscape fitting so the canvas fills its container and refits on resize

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d037eef8e48320a2bde6ae47065bad