### PR TITLE
Polish graph UI layout and node labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An offline, client-side viewer that parses Tableau `.twb` and `.twbx` workbooks 
 - Runs entirely in the browser (no servers, no telemetry, no network access required)
 - Supports Tableau `.twb` (XML) and `.twbx` (packaged) files
 - Interactive Cytoscape graph with pan/zoom/drag, neighbor expansion, and search
+- Node labels automatically adjust contrast per theme, truncate with ellipses, and expose full names on hover
 - Sidebar lists for fields, calculated fields, worksheets, and parameters
 - Detail panel with formulas, references, and usage
 - Filter controls for node types, LOD-only, and table-calculation-only views
@@ -20,11 +21,11 @@ An offline, client-side viewer that parses Tableau `.twb` and `.twbx` workbooks 
   - `--gem-primary`, `--gem-primary-2`, `--gem-primary-3`, `--gem-accent`
   - `--gem-success`, `--gem-warning`
   - Utility tokens: `--gem-border`, `--gem-shadow`, `--gem-glow`, `--radius`, `--radius-lg`, `--pad`, `--trans`
-- The header logo and favicon are inline SVG data URIs inside `index.html` so the project stays binary-free for Codex PRs. Replace them later by editing the markup in `index.html` if you have custom artwork.
+- The header logo first attempts to load `./assets/gem-logo.png`; if unavailable it falls back to the inline SVG contained in `index.html` so the app remains binary-free by default.
 
 ## Toolbar
 
-- Slim horizontal bar with logo left, search centered, controls right.
+- Slim single-line toolbar with logo on the left, centered search, and controls on the right sized for a compact 42px header.
 - Hop dropdown (1–5) replaces expand1/2 buttons.
 
 ## Getting started

--- a/app.js
+++ b/app.js
@@ -304,15 +304,15 @@ function bindUI() {
 }
 
 function bootGraph() {
-  const graphEl = document.getElementById('graph');
-  if (!graphEl) {
+  const graphContainerEl = document.getElementById('graph');
+  if (!graphContainerEl) {
     throw new Error('Graph container missing.');
   }
 
   const layoutName = (typeof hasBilkent !== 'undefined' && hasBilkent) ? 'cose-bilkent' : 'cose';
 
   state.cy = cytoscape({
-    container: graphEl,
+    container: graphContainerEl,
     wheelSensitivity: 0.2,
     autoungrabify: false,
     layout: {
@@ -338,9 +338,11 @@ function bootGraph() {
           'text-wrap': 'wrap',
           'text-valign': 'center',
           'text-halign': 'center',
-          'text-max-width': 120,
-          'text-outline-color': 'rgba(0,0,0,.55)',
-          'text-outline-width': 2,
+          'text-max-width': '120px',
+          'text-outline-color': 'var(--label-outline)',
+          'text-outline-width': 2.5,
+          'text-overflow-wrap': 'ellipsis',
+          'min-zoomed-font-size': 10,
           'border-width': 1.5,
           'border-color': 'rgba(14, 11, 20, 0.45)',
           'overlay-opacity': 0,
@@ -417,6 +419,20 @@ function bootGraph() {
     ],
   });
 
+  const graphEl = () => state.cy && state.cy.container();
+  state.cy.on('mouseover', 'node', (e) => {
+    const el = graphEl();
+    if (el) {
+      el.title = e.target.data('name') || '';
+    }
+  });
+  state.cy.on('mouseout', 'node', () => {
+    const el = graphEl();
+    if (el) {
+      el.title = '';
+    }
+  });
+
   if (state.graphResizeObserver) {
     try {
       state.graphResizeObserver.disconnect();
@@ -426,14 +442,14 @@ function bootGraph() {
     state.graphResizeObserver = null;
   }
 
-  if (window.ResizeObserver && graphEl) {
+  if (window.ResizeObserver && graphContainerEl) {
     const ro = new ResizeObserver(() => {
       if (state.cy) {
         state.cy.resize();
         fitGraph();
       }
     });
-    ro.observe(graphEl);
+    ro.observe(graphContainerEl);
     state.graphResizeObserver = ro;
   }
 

--- a/index.html
+++ b/index.html
@@ -20,21 +20,21 @@
   </head>
   <body>
     <header class="topbar">
-      <div class="topbar-left">
+      <div class="left">
         <a class="brand" href="./">
           <img id="brandLogo" alt="Gem" />
           <span class="brand-name">Gem</span>
         </a>
         <button class="btn" id="openBtn" type="button">Open Workbook</button>
       </div>
-      <div class="topbar-center">
+      <div class="center">
         <form id="search-form" role="search">
           <label for="search" class="visually-hidden">Search nodes</label>
           <input id="search" name="q" type="search" placeholder="Search..." list="node-names" autocomplete="off" />
           <datalist id="node-names"></datalist>
         </form>
       </div>
-      <div class="topbar-right">
+      <div class="right">
         <button class="btn" id="fitBtn" type="button" title="Zoom to the visible graph">Fit</button>
         <button class="btn" id="layoutBtn" type="button" title="Re-run the layout to spread nodes">Auto layout</button>
         <label for="hopSelect" class="visually-hidden">Expand neighbors hops</label>

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --topbar-h: 48px;
-  --footer-h: 0px;
+  --topbar-h: 42px;
+  --footer-h: 40px;
   --gem-bg: #0E0B14;
   --gem-surface: #151827;
   --gem-surface-2: #1b2030;
@@ -20,6 +20,7 @@
   --pad: 10px;
   --trans: 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
   --font-stack: 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  --label-outline: rgba(0, 0, 0, 0.65);
 }
 
 html.light,
@@ -36,6 +37,7 @@ html.light,
   --gem-accent: #B794F4;
   --gem-shadow: 0 12px 26px rgba(0, 0, 0, 0.12);
   --gem-glow: 0 0 0 2px rgba(124, 58, 237, 0.2), 0 12px 28px rgba(124, 58, 237, 0.18);
+  --label-outline: rgba(255, 255, 255, 0.75);
 }
 
 * {
@@ -45,8 +47,10 @@ html.light,
 body {
   margin: 0;
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   font-family: var(--font-stack);
   background:
     radial-gradient(1200px 600px at 20% -10%, rgba(124, 58, 237, 0.25), transparent 60%),
@@ -81,47 +85,37 @@ summary {
   backdrop-filter: blur(24px);
 }
 
-header.topbar {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  display: flex;
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 6px 16px;
-  height: var(--topbar-h);
+  height: 42px;
+  padding: 4px 10px;
   background: var(--gem-surface);
   border-bottom: 1px solid var(--gem-border);
-  flex-wrap: wrap;
-  row-gap: 8px;
-  width: 100%;
-  box-sizing: border-box;
+  box-shadow: none;
+  border-radius: 0;
+  column-gap: 16px;
+  position: relative;
+  z-index: 15;
+  flex-shrink: 0;
 }
 
-.topbar-left,
-.topbar-right {
+.topbar .left,
+.topbar .center,
+.topbar .right {
   display: flex;
   align-items: center;
-  gap: 10px;
-}
-
-.topbar-left {
-  flex-wrap: wrap;
+  gap: 8px;
   min-width: 0;
 }
 
-.topbar-center {
-  flex: 1;
-  display: flex;
+.topbar .center {
   justify-content: center;
-  min-width: 0;
 }
 
-.topbar-right {
-  flex-wrap: wrap;
+.topbar .right {
   justify-content: flex-end;
-  min-width: 0;
 }
 
 .brand {
@@ -167,9 +161,9 @@ header.topbar {
   background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
   border: 1px solid var(--gem-border);
   border-radius: 999px;
-  padding: 6px 10px;
+  padding: 5px 10px;
   color: var(--gem-text);
-  font-size: 0.9rem;
+  font-size: 13px;
   cursor: pointer;
   transition: transform var(--trans), box-shadow var(--trans), background var(--trans), border var(--trans);
 }
@@ -185,13 +179,14 @@ summary {
   list-style: none;
   cursor: pointer;
   border-radius: 999px;
-  padding: 6px 10px;
+  padding: 5px 10px;
   border: 1px solid var(--gem-border);
   background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
   transition: border var(--trans), box-shadow var(--trans);
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  font-size: 13px;
 }
 
 .dropdown {
@@ -255,9 +250,10 @@ summary::-webkit-details-marker {
 #search-form {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   width: 100%;
-  max-width: 420px;
+  max-width: 520px;
+  margin: 0;
 }
 
 #search {
@@ -265,11 +261,12 @@ summary::-webkit-details-marker {
   border: 1px solid var(--gem-border);
   border-radius: 999px;
   color: var(--gem-text);
-  padding: 6px 12px;
-  min-width: 220px;
-  max-width: 420px;
+  padding: 4px 12px;
+  min-width: 260px;
+  max-width: 520px;
   width: 100%;
   transition: border var(--trans), box-shadow var(--trans);
+  height: 30px;
 }
 
 #search:focus {
@@ -279,20 +276,22 @@ summary::-webkit-details-marker {
 
 #hopSelect {
   appearance: none;
-  background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
-  border: 1px solid var(--gem-border);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 6px 24px 6px 10px;
   border-radius: 999px;
-  padding: 6px 32px 6px 12px;
+  border: 1px solid var(--gem-border);
+  background: var(--gem-surface);
   color: var(--gem-text);
-  font-size: 0.9rem;
+  font-size: 13px;
   cursor: pointer;
-  min-width: 132px;
+  min-width: 124px;
   line-height: 1.2;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%23A78BFA' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 12px center;
+  background-position: right 10px center;
   background-size: 12px;
-  transition: border var(--trans), box-shadow var(--trans);
+  transition: border var(--trans), box-shadow var(--trans), background var(--trans);
 }
 
 #hopSelect:focus {
@@ -310,6 +309,8 @@ summary::-webkit-details-marker {
   gap: 12px;
   height: calc(100vh - var(--topbar-h) - var(--footer-h));
   padding: 16px;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -335,7 +336,7 @@ summary::-webkit-details-marker {
 .graphwrap {
   grid-area: graph;
   position: relative;
-  min-height: 540px;
+  min-height: 0;
   height: 100%;
   min-width: 360px;
   overflow: hidden;
@@ -489,16 +490,16 @@ summary::-webkit-details-marker {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
-  margin: 0 16px 16px;
-  padding: 12px 18px;
-  min-height: var(--footer-h);
+  gap: 12px;
+  margin: 0;
+  padding: 0 16px;
+  height: var(--footer-h);
   font-size: 0.85rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02)), var(--gem-surface);
-  border: 1px solid var(--gem-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--gem-shadow);
-  backdrop-filter: blur(20px);
+  background: var(--gem-surface);
+  border-top: 1px solid var(--gem-border);
+  border-radius: 0;
+  box-shadow: none;
+  flex-shrink: 0;
 }
 
 .status-bar span:last-child {
@@ -543,22 +544,26 @@ summary::-webkit-details-marker {
 }
 
 @media (max-width: 980px) {
-  header.topbar {
+  .topbar {
+    grid-template-columns: 1fr;
     height: auto;
+    row-gap: 8px;
   }
 
-  .topbar-left,
-  .topbar-right,
-  .topbar-center {
+  .topbar .left,
+  .topbar .center,
+  .topbar .right {
     width: 100%;
-  }
-
-  .topbar-center {
     justify-content: center;
+    flex-wrap: wrap;
   }
 
-  .topbar-right {
-    justify-content: flex-start;
+  .topbar .left {
+    justify-content: space-between;
+  }
+
+  .topbar .right {
+    justify-content: center;
   }
 }
 
@@ -585,10 +590,11 @@ summary::-webkit-details-marker {
     width: 100%;
   }
 
-  .topbar-left,
-  .topbar-right {
+  .topbar .left,
+  .topbar .right {
     width: 100%;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 6px;
   }
 }
 


### PR DESCRIPTION
## Summary
- slim the header into a 42px grid with centered search, sized controls, and viewport-fitting layout tweaks
- improve Cytoscape node label contrast with ellipsis wrapping plus hover tooltips for full names
- refresh the README to describe the updated toolbar and labeling behaviour

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0b22a4b3083209de7adcdd9aac812