### PR TITLE
feat: livelier graph layout and isolated node controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,11 @@
           <option value="5">5 hops</option>
         </select>
         <button class="btn" id="hideIsolatedBtn" type="button">Hide isolated</button>
+        <select id="isolatedMode" title="How to display isolated nodes">
+          <option value="cluster" selected>Isolated: Cluster</option>
+          <option value="hide">Isolated: Hide</option>
+          <option value="scatter">Isolated: Scatter</option>
+        </select>
         <details class="dropdown" id="filters-dropdown">
           <summary>Filters</summary>
           <div class="menu">

--- a/styles.css
+++ b/styles.css
@@ -175,6 +175,18 @@ summary {
   outline: none;
 }
 
+#isolatedMode {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--gem-border);
+  background: var(--gem-surface);
+  color: var(--gem-text);
+  font-size: 13px;
+}
+
 summary {
   list-style: none;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add top bar selector to switch how isolated nodes are displayed (cluster, hide, scatter)
- implement soft neo4j-style auto layout helper with nudge support and isolated node clustering logic
- trigger gentle relayouts after key interactions and style the new isolated selector to match pill controls

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d18589354083208c6056691dec18ee