### PR TITLE
feat: isolated control dropdown & breathing layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An offline, client-side viewer that parses Tableau `.twb` and `.twbx` workbooks 
 - Supports Tableau `.twb` (XML) and `.twbx` (packaged) files
 - Interactive Cytoscape graph with pan/zoom/drag, neighbor expansion, and search
 - Node labels automatically adjust contrast per theme, truncate with ellipses, and expose full names on hover
+- Layout "breathes" after major actions (load, fit, auto layout, expand neighbors, filters, isolated mode changes) and when
+  hovering or tapping nodes; when zoomed out the labels hide until there's room, but hovering always reveals the name
 - Sidebar lists for fields, calculated fields, worksheets, and parameters
 - Detail panel with formulas, references, and usage
 - Filter controls for node types, LOD-only, and table-calculation-only views

--- a/index.html
+++ b/index.html
@@ -45,12 +45,22 @@
           <option value="4">4 hops</option>
           <option value="5">5 hops</option>
         </select>
-        <button class="btn" id="hideIsolatedBtn" type="button">Hide isolated</button>
-        <select id="isolatedMode" title="How to display isolated nodes">
-          <option value="cluster" selected>Isolated: Cluster</option>
-          <option value="hide">Isolated: Hide</option>
-          <option value="scatter">Isolated: Scatter</option>
-        </select>
+        <div class="dropdown">
+          <button
+            id="isolatedBtn"
+            class="btn"
+            type="button"
+            title="Control isolated nodes"
+          >
+            Isolated ▾
+          </button>
+          <div id="isolatedMenu" class="menu">
+            <button class="menu-item" type="button" data-iso="hide">Hide</button>
+            <button class="menu-item" type="button" data-iso="cluster">Cluster</button>
+            <button class="menu-item" type="button" data-iso="scatter">Scatter</button>
+            <button class="menu-item" type="button" data-iso="unhide">Unhide</button>
+          </div>
+        </div>
         <details class="dropdown" id="filters-dropdown">
           <summary>Filters</summary>
           <div class="menu">

--- a/styles.css
+++ b/styles.css
@@ -175,18 +175,6 @@ summary {
   outline: none;
 }
 
-#isolatedMode {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  padding: 6px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--gem-border);
-  background: var(--gem-surface);
-  color: var(--gem-text);
-  font-size: 13px;
-}
-
 summary {
   list-style: none;
   cursor: pointer;
@@ -201,10 +189,6 @@ summary {
   font-size: 13px;
 }
 
-.dropdown {
-  position: relative;
-}
-
 summary::after {
   content: '▾';
   font-size: 0.75rem;
@@ -215,19 +199,24 @@ summary::-webkit-details-marker {
   display: none;
 }
 
+.dropdown {
+  position: relative;
+}
+
 .dropdown[open] > summary {
   box-shadow: var(--gem-glow);
   border-color: rgba(139, 92, 246, 0.45);
 }
 
-.dropdown .menu,
-.dropdown .dropdown-menu {
+.dropdown > .menu,
+.dropdown > .dropdown-menu {
   position: absolute;
-  top: calc(100% + 10px);
-  left: 0;
+  right: 0;
+  top: 100%;
+  margin-top: 8px;
   min-width: 200px;
   padding: 12px;
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 10px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)), var(--gem-surface);
@@ -235,6 +224,13 @@ summary::-webkit-details-marker {
   border-radius: 16px;
   box-shadow: var(--gem-shadow);
   z-index: 20;
+}
+
+.dropdown.open > .menu,
+.dropdown.open > .dropdown-menu,
+.dropdown[open] > .menu,
+.dropdown[open] > .dropdown-menu {
+  display: flex;
 }
 
 .dropdown .menu hr {
@@ -248,6 +244,31 @@ summary::-webkit-details-marker {
   align-items: center;
   gap: 8px;
   font-size: 0.85rem;
+}
+
+.dropdown .menu .menu-item {
+  width: 100%;
+  text-align: left;
+  background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
+  border: 1px solid var(--gem-border);
+  border-radius: 999px;
+  padding: 6px 12px;
+  color: var(--gem-text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: transform var(--trans), box-shadow var(--trans), border var(--trans), background var(--trans);
+}
+
+.dropdown .menu .menu-item:hover,
+.dropdown .menu .menu-item:focus-visible,
+.dropdown .menu .menu-item.active {
+  box-shadow: var(--gem-glow);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.dropdown .menu .menu-item.active {
+  border-color: rgba(139, 92, 246, 0.45);
 }
 
 .dropdown .menu button {


### PR DESCRIPTION
## Summary
- replace the standalone hide/isolated select with a pill-style dropdown and sync the button/menu state
- add breathing layout helpers, hook them to major actions and node interactions, and adjust isolated node behaviors
- tweak node labels for readability/tooltip visibility and note the breathing behavior in the README

## Testing
- no automated tests (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d18d12efc88320921ac4cb8b49f88f