### PR TITLE
fix: sync Cytoscape styling with theme colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,10 @@
   --label-outline: rgba(0, 0, 0, 0.65);
 }
 
+html.light {
+  --label-outline: rgba(255, 255, 255, 0.75);
+}
+
 html.light,
 :root.light {
   --gem-bg: #F7F7FB;


### PR DESCRIPTION
## Summary
- read Cytoscape palette values from CSS variables and centralize styling via `applyCyTheme`
- size graph nodes to their labels, show the full workbook graph on load, and reuse a shared `fitAll` helper after key actions
- keep hover tooltips while adding a light theme label outline fallback so colors stay legible in both themes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d19fb0a8f88320a477b7236cb27aa3