### PR TITLE
Ensure workbook graphs render completely with styled edges

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,10 @@ html.light {
   --label-outline: rgba(255, 255, 255, 0.75);
 }
 
+html.light .cy-edge-label {
+  filter: none;
+}
+
 html.light,
 :root.light {
   --gem-bg: #F7F7FB;


### PR DESCRIPTION
## Summary
- rebuild drawGraph to batch add nodes then edges, show everything, and run isolated handling before fit and breathe
- enhance Cytoscape theming with manual z-indexing and labelled edges, plus light-mode edge label tweak
- track active layouts so fit/breathe wait for completion and update isolated handling to avoid mass hiding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a6ca3760832080d516873d54b28d