### PR TITLE
Stabilize graph rendering and remove auto layout breathing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,12 @@
 :root {
+  --label-outline: rgba(0, 0, 0, 0.65);
+}
+
+html.light {
+  --label-outline: rgba(255, 255, 255, 0.75);
+}
+
+:root {
   --topbar-h: 42px;
   --footer-h: 40px;
   --gem-bg: #0E0B14;


### PR DESCRIPTION
## Summary
- update Cytoscape theming and fit helpers so nodes and connectors stay visible with readable labels
- rebuild drawGraph to add nodes then edges, apply the theme, default to neutral isolated mode, and fit once without auto relayouts
- simplify UI interactions so fit/auto layout triggers are manual-only while isolated handling respects filters and exposes unhide by default

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1ac12e2e48320a4175b0c634a84c8