### PR TITLE
Add layout menu and improve graph layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,17 @@
       <div class="right">
         <button class="btn" id="fitBtn" type="button" title="Zoom to the visible graph">Fit</button>
         <button class="btn" id="layoutBtn" type="button" title="Re-run the layout to spread nodes">Auto layout</button>
+        <div class="dropdown">
+          <button id="layoutMenuBtn" class="btn" title="Choose layout">Layout ▾</button>
+          <div id="layoutMenu" class="menu">
+            <button class="menu-item" data-layout="force">Force</button>
+            <button class="menu-item" data-layout="grid">Grid</button>
+            <button class="menu-item" data-layout="hierarchy">Hierarchy</button>
+            <button class="menu-item" data-layout="centered">Centered hierarchy</button>
+            <button class="menu-item" data-layout="centered-selected">Centered from selection</button>
+          </div>
+        </div>
+        <span id="layoutStatus" class="chip" aria-live="polite">Layout: Auto</span>
         <label for="hopSelect" class="visually-hidden">Expand neighbors hops</label>
         <select id="hopSelect" title="Expand neighbors this many hops">
           <option value="1">1 hop</option>

--- a/styles.css
+++ b/styles.css
@@ -184,6 +184,16 @@ summary {
   transition: transform var(--trans), box-shadow var(--trans), background var(--trans), border var(--trans);
 }
 
+.chip {
+  background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
+  border: 1px solid var(--gem-border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--gem-text);
+  margin-left: 6px;
+}
+
 .btn:hover,
 .btn:focus-visible {
   box-shadow: var(--gem-glow);
@@ -589,7 +599,7 @@ summary::-webkit-details-marker {
 
 .faded {
   opacity: 0.18;
-  transition: opacity var(--trans);
+  transition: opacity 160ms ease;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
## Summary
- add a Layout dropdown menu, route each option to new layout runners, and surface the active layout in a status chip
- center node labels, enable edge labels, and keep nodes draggable with faster wheel zoom and interaction affordances
- update graph loading to reset layout status, ensure nodes stay grab-enabled, and wire non-destructive highlight behaviors

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1c8b43da48320af40dbfbe8eac1b5