### PR TITLE
refactor(layout-ui): remove status pill; show active layout in Layout ▾ button; keep dropdown wiring; ensure node labels render inside boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,17 +37,24 @@
       <div class="right">
         <button class="btn" id="fitBtn" type="button" title="Zoom to the visible graph">Fit</button>
         <button class="btn" id="layoutBtn" type="button" title="Re-run the layout to spread nodes">Auto layout</button>
-        <div class="dropdown">
-          <button id="layoutMenuBtn" class="btn" title="Choose layout">Layout ▾</button>
-          <div id="layoutMenu" class="menu">
-            <button class="menu-item" data-layout="force">Force</button>
-            <button class="menu-item" data-layout="grid">Grid</button>
-            <button class="menu-item" data-layout="hierarchy">Hierarchy</button>
-            <button class="menu-item" data-layout="centered">Centered hierarchy</button>
-            <button class="menu-item" data-layout="centered-selected">Centered from selection</button>
+        <div class="dropdown" id="layoutDropdown">
+          <button
+            id="layoutMenuBtn"
+            class="btn"
+            title="Choose layout"
+            aria-haspopup="true"
+            aria-expanded="false"
+          >
+            Layout: Auto ▾
+          </button>
+          <div id="layoutMenu" class="menu" role="menu" aria-label="Layout menu">
+            <button class="menu-item" data-layout="force" role="menuitem">Force</button>
+            <button class="menu-item" data-layout="grid" role="menuitem">Grid</button>
+            <button class="menu-item" data-layout="hierarchy" role="menuitem">Hierarchy</button>
+            <button class="menu-item" data-layout="centered" role="menuitem">Centered hierarchy</button>
+            <button class="menu-item" data-layout="centered-selected" role="menuitem">Centered from selection</button>
           </div>
         </div>
-        <span id="layoutStatus" class="chip" aria-live="polite">Layout: Auto</span>
         <label for="hopSelect" class="visually-hidden">Expand neighbors hops</label>
         <select id="hopSelect" title="Expand neighbors this many hops">
           <option value="1">1 hop</option>

--- a/styles.css
+++ b/styles.css
@@ -113,7 +113,7 @@ summary {
   border-radius: 0;
   column-gap: 16px;
   position: relative;
-  z-index: 15;
+  z-index: 2000;
   flex-shrink: 0;
 }
 
@@ -227,6 +227,7 @@ summary::-webkit-details-marker {
 
 .dropdown {
   position: relative;
+  z-index: 2000;
 }
 
 .dropdown[open] > summary {
@@ -234,29 +235,24 @@ summary::-webkit-details-marker {
   border-color: rgba(139, 92, 246, 0.45);
 }
 
-.dropdown > .menu,
-.dropdown > .dropdown-menu {
+.dropdown .menu {
   position: absolute;
   right: 0;
   top: 100%;
-  margin-top: 8px;
-  min-width: 200px;
-  padding: 12px;
   display: none;
-  flex-direction: column;
-  gap: 10px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)), var(--gem-surface);
+  min-width: 180px;
+  background: var(--gem-surface);
   border: 1px solid var(--gem-border);
-  border-radius: 16px;
+  border-radius: 14px;
+  padding: 6px;
   box-shadow: var(--gem-shadow);
-  z-index: 20;
+  z-index: 2000;
+  pointer-events: auto;
 }
 
-.dropdown.open > .menu,
-.dropdown.open > .dropdown-menu,
-.dropdown[open] > .menu,
-.dropdown[open] > .dropdown-menu {
-  display: flex;
+.dropdown.open .menu,
+.dropdown[open] > .menu {
+  display: block;
 }
 
 .dropdown .menu hr {
@@ -272,29 +268,30 @@ summary::-webkit-details-marker {
   font-size: 0.85rem;
 }
 
-.dropdown .menu .menu-item {
+.menu-item {
   width: 100%;
   text-align: left;
-  background: linear-gradient(180deg, var(--gem-surface-2), var(--gem-surface));
-  border: 1px solid var(--gem-border);
-  border-radius: 999px;
-  padding: 6px 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: transparent;
+  border: 0;
   color: var(--gem-text);
   font-size: 13px;
   cursor: pointer;
-  transition: transform var(--trans), box-shadow var(--trans), border var(--trans), background var(--trans);
 }
 
-.dropdown .menu .menu-item:hover,
-.dropdown .menu .menu-item:focus-visible,
-.dropdown .menu .menu-item.active {
-  box-shadow: var(--gem-glow);
-  transform: translateY(-1px);
+.menu-item:hover {
+  background: rgba(139, 92, 246, 0.12);
+  cursor: pointer;
+}
+
+.menu-item:focus-visible {
   outline: none;
+  box-shadow: var(--gem-glow);
 }
 
-.dropdown .menu .menu-item.active {
-  border-color: rgba(139, 92, 246, 0.45);
+.menu-item.active {
+  background: rgba(139, 92, 246, 0.18);
 }
 
 .dropdown .menu button {
@@ -399,6 +396,18 @@ summary::-webkit-details-marker {
   height: 100%;
   min-width: 360px;
   overflow: hidden;
+}
+
+#graph,
+#graph-container,
+.graphwrap {
+  z-index: 1;
+}
+
+.topbar,
+.dropdown,
+.menu {
+  z-index: 2000;
 }
 
 /* The Cytoscape mount must fill graphwrap */


### PR DESCRIPTION
## Summary
- show the selected layout within the Layout ▾ control and remove the extra status chip
- adjust dropdown layering so menus stay above the graph canvas
- center node labels inside each box and update layout runners to sync the button label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1d301e6d88320b52059122f8dee22