### PR TITLE
Update Pages workflow actions to latest versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- bump `actions/upload-pages-artifact` to v3 to address deprecation notice
- bump `actions/deploy-pages` to v4 in the GitHub Pages workflow

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2c61f4dcc832084f265e4b739ecf1