### PR TITLE
Improve details panel formula rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Supported files: Tableau `.twb` (XML) and `.twbx` (packaged) workbooks.
 - **Theme** (`themeBtn`): Switch between Dark and Light themes for the current session.
 - **Drag/Zoom**: Pan with the mouse, scroll to zoom, and drag nodes to adjust their placement.
 
+### Details panel
+
+The right-hand `details` pane mirrors the selected node, showing its type, datasource, and any
+related worksheets or dashboards so you can trace dependencies without leaving the graph.
+
+#### Formula display
+
+Formulas render inside a `<pre>` block as plain text, so Tableau syntax like `<` and `>` stays
+visible and any user-authored HTML is escaped automatically. The Formula heading displays **LOD** and
+**Table Calc** chips whenever the expression uses `{}` level-of-detail braces, the table-calculation
+flag is set, or `WINDOW_`/`RUNNING_` keywords appear. Long expressions wrap, break on extended tokens,
+and scroll inside a 240px container, keeping every character legible without overflowing the panel.
+
 ## 4. Exports
 
 - `workbook_doc.json`: Structured metadata for the full workbook (fields, calculated fields,

--- a/styles.css
+++ b/styles.css
@@ -585,6 +585,37 @@ summary::-webkit-details-marker {
   overflow-x: auto;
 }
 
+.details .formula {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--gem-surface);
+  border: 1px solid var(--gem-border);
+  border-radius: 10px;
+  padding: 10px;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.chip {
+  display: inline-block;
+  font-size: 12px;
+  padding: 2px 6px;
+  margin-left: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--gem-border);
+  background: var(--gem-surface-2);
+  color: var(--gem-text);
+}
+
+.chip-lod {
+  border-color: rgba(139, 92, 246, 0.45);
+}
+
+.chip-table {
+  border-color: rgba(34, 211, 238, 0.45);
+}
+
 /* -------------------------------------------------------------------------- */
 /* Footer status bar                                                          */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- render calculated field formulas inside a dedicated `<pre class="formula">` with safe textContent
- show LOD/Table Calc chips beside the heading when braces or table calc keywords/flags are present
- style the formula block and document the new behaviour in the README

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d428157998832097191c506667c59f