### PR TITLE
feat: Sidebar collapsible dropdowns with multi-select for Sheets, Cal…

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,24 +114,55 @@
 
     <!-- Main layout: sidebar lists, graph canvas, and details panel -->
     <main class="layout" role="main">
-      <!-- Sidebar with drop zone and workbook navigation tabs -->
+      <!-- Sidebar with drop zone and collapsible workbook navigation -->
       <aside class="sidebar">
         <section id="dropZone" class="dropzone" aria-label="Workbook drop zone" tabindex="0">
           <!-- Loader wiring expects this stable ID (see ID invariants in app.js). -->
           <input id="fileInput" type="file" accept=".twb,.twbx" hidden />
           <p>Drop a Tableau .twb or .twbx file here<br />or click Open Workbook.</p>
         </section>
-        <!-- Sidebar tabs allow switching between node, sheet, calc, and parameter lists -->
-        <div class="sidebar-section">
-          <p class="sidebar-label">Dashboards</p>
-          <p class="sidebar-hint">Click to filter graph and export</p>
-          <ul id="list-dashboards" aria-label="Dashboard filter list"></ul>
-          <button id="clearDashboardFilter" class="btn btn-sm" type="button" style="display:none">Show all</button>
-        </div>
-        <div class="sidebar-section">
-          <p class="sidebar-label">Sheets</p>
-          <ul id="list-sheets" aria-label="Sheet list"></ul>
-        </div>
+
+        <!-- Dashboards — single-select filter -->
+        <details class="sidebar-group" id="sidebar-dashboards" open>
+          <summary>Dashboards <span class="sidebar-count" id="dashboards-count"></span></summary>
+          <div class="sidebar-group-body">
+            <p class="sidebar-hint">Click to filter graph</p>
+            <ul id="list-dashboards" aria-label="Dashboard filter list"></ul>
+            <button id="clearDashboardFilter" class="btn btn-sm" type="button" style="display:none">Show all</button>
+          </div>
+        </details>
+
+        <!-- Sheets — multi-select -->
+        <details class="sidebar-group" id="sidebar-sheets">
+          <summary>Sheets <span class="sidebar-count" id="sheets-count"></span></summary>
+          <div class="sidebar-group-body">
+            <ul id="list-sheets" aria-label="Sheet list"></ul>
+          </div>
+        </details>
+
+        <!-- Calculations — multi-select -->
+        <details class="sidebar-group" id="sidebar-calcs">
+          <summary>Calculations <span class="sidebar-count" id="calcs-count"></span></summary>
+          <div class="sidebar-group-body">
+            <ul id="list-calcs" aria-label="Calculations list"></ul>
+          </div>
+        </details>
+
+        <!-- Parameters — multi-select -->
+        <details class="sidebar-group" id="sidebar-params">
+          <summary>Parameters <span class="sidebar-count" id="params-count"></span></summary>
+          <div class="sidebar-group-body">
+            <ul id="list-params" aria-label="Parameters list"></ul>
+          </div>
+        </details>
+
+        <!-- Relationships — multi-select edges -->
+        <details class="sidebar-group" id="sidebar-relationships">
+          <summary>Relationships <span class="sidebar-count" id="relationships-count"></span></summary>
+          <div class="sidebar-group-body">
+            <ul id="list-relationships" aria-label="Relationships list"></ul>
+          </div>
+        </details>
       </aside>
 
       <!-- Cytoscape graph container and status overlay -->

--- a/src/filters.js
+++ b/src/filters.js
@@ -62,6 +62,39 @@ export function clearDashboardFilter() {
 }
 
 /**
+ * Filters the graph to show nodes in the given set and their direct neighbors.
+ * Used for sidebar multi-select filtering across sheets, calcs, params, and relationships.
+ *
+ * @param {Set<string>} selectedNodeIds - Set of selected node IDs to display
+ */
+export function filterBySidebarSelection(selectedNodeIds) {
+  if (!state.cy) return;
+
+  if (!selectedNodeIds || selectedNodeIds.size === 0) {
+    // Nothing selected — restore full graph with type filters applied
+    state.cy.elements().show();
+    applyFilters({ rerunLayout: false });
+    fitAll(80);
+    return;
+  }
+
+  let combined = state.cy.collection();
+  selectedNodeIds.forEach((nodeId) => {
+    const node = state.cy.getElementById(nodeId);
+    if (node && node.length) {
+      combined = combined.union(node.closedNeighborhood());
+    }
+  });
+
+  state.cy.batch(() => {
+    state.cy.elements().hide();
+    combined.show();
+  });
+
+  fitAll(80);
+}
+
+/**
  * Fits viewport to all visible elements
  * @param {number} pad - Padding around elements
  */

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -329,16 +329,21 @@ export function syncListSelection(nodeId) {
 }
 
 /**
- * Populates sidebar lists for dashboards and sheets
- * Also refreshes the datalist used by the search box
+ * Populates all sidebar lists: dashboards, sheets, calculations, parameters, relationships.
+ * Also refreshes the datalist used by the search box.
  *
  * @param {Object} meta - Parsed metadata object
  * @param {Object} dependencies - External function dependencies
- * @param {Function} dependencies.focusOnNode - Function to focus on node
+ * @param {Function} dependencies.filterByDashboard - Filter graph to a dashboard subgraph
+ * @param {Function} dependencies.clearDashboardFilter - Restore full graph
+ * @param {Function} dependencies.filterBySidebarSelection - Filter graph by selected node IDs
  */
 export function populateLists(meta, dependencies = {}) {
   const dashboardsList = document.getElementById('list-dashboards');
   const sheetsList = document.getElementById('list-sheets');
+  const calcsList = document.getElementById('list-calcs');
+  const paramsList = document.getElementById('list-params');
+  const relationshipsList = document.getElementById('list-relationships');
   const clearBtn = document.getElementById('clearDashboardFilter');
   const datalist = document.getElementById('node-names');
 
@@ -358,9 +363,80 @@ export function populateLists(meta, dependencies = {}) {
 
   dashboardsList.innerHTML = '';
   sheetsList.innerHTML = '';
+  if (calcsList) calcsList.innerHTML = '';
+  if (paramsList) paramsList.innerHTML = '';
+  if (relationshipsList) relationshipsList.innerHTML = '';
   datalist.innerHTML = '';
 
-  // Build dashboard list - clicking filters graph to that dashboard
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  /** Updates a count badge element */
+  function setCount(id, n) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = n > 0 ? String(n) : '';
+  }
+
+  /** Reads all currently-active sidebar node selections from the DOM */
+  function getSelectedNodeIds() {
+    const ids = new Set();
+    document.querySelectorAll('.sidebar-item-btn.active[data-node-id]').forEach((btn) => {
+      ids.add(btn.dataset.nodeId);
+    });
+    document.querySelectorAll('.sidebar-item-btn.active[data-source-id]').forEach((btn) => {
+      if (btn.dataset.sourceId) ids.add(btn.dataset.sourceId);
+      if (btn.dataset.targetId) ids.add(btn.dataset.targetId);
+    });
+    return ids;
+  }
+
+  /** Called whenever any multi-select toggle changes */
+  function onSelectionChange() {
+    const ids = getSelectedNodeIds();
+    if (dependencies.filterBySidebarSelection) {
+      dependencies.filterBySidebarSelection(ids);
+    }
+  }
+
+  /**
+   * Creates a toggleable sidebar list item button for multi-select.
+   * @param {string} label - Display text
+   * @param {string|null} nodeId - Graph node ID
+   * @param {Object} [edgeIds] - Optional { sourceId, targetId } for edge items
+   * @param {string} [extraClass] - Extra CSS class
+   */
+  function createToggleItem(label, nodeId, edgeIds = null, extraClass = '') {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.title = label;
+    button.className = 'sidebar-item-btn' + (extraClass ? ' ' + extraClass : '');
+
+    if (nodeId) {
+      button.dataset.nodeId = nodeId;
+    }
+    if (edgeIds) {
+      button.dataset.sourceId = edgeIds.sourceId || '';
+      button.dataset.targetId = edgeIds.targetId || '';
+    }
+
+    if (nodeId || edgeIds) {
+      button.addEventListener('click', () => {
+        const wasActive = button.classList.contains('active');
+        button.classList.toggle('active', !wasActive);
+        button.setAttribute('aria-pressed', wasActive ? 'false' : 'true');
+        onSelectionChange();
+      });
+    } else {
+      button.disabled = true;
+    }
+
+    li.appendChild(button);
+    return li;
+  }
+
+  // ── Dashboards (single-select filter, existing behaviour) ────────────────
+
   const dashboardData = (meta.dashboards || [])
     .filter((db) => db && db.name)
     .map((db) => {
@@ -380,13 +456,11 @@ export function populateLists(meta, dependencies = {}) {
       button.dataset.nodeId = db.nodeId;
       button.dataset.dashboardName = db.name;
       button.addEventListener('click', () => {
-        // Toggle selection
         const isActive = button.classList.contains('active');
         dashboardsList.querySelectorAll('.dashboard-filter-btn').forEach((b) =>
           b.classList.remove('active')
         );
         if (isActive) {
-          // Deselect - clear filter
           state.selectedDashboard = null;
           if (clearBtn) clearBtn.style.display = 'none';
           if (dependencies.clearDashboardFilter) dependencies.clearDashboardFilter();
@@ -404,7 +478,8 @@ export function populateLists(meta, dependencies = {}) {
     dashboardsList.appendChild(li);
   });
 
-  // Wire up "Show all" button
+  setCount('dashboards-count', dashboardData.length);
+
   if (clearBtn) {
     clearBtn.addEventListener('click', () => {
       state.selectedDashboard = null;
@@ -416,7 +491,8 @@ export function populateLists(meta, dependencies = {}) {
     });
   }
 
-  // Build sheets list
+  // ── Sheets (multi-select) ────────────────────────────────────────────────
+
   const worksheetData = (meta.worksheets || [])
     .filter((ws) => ws && ws.name)
     .map((ws) => {
@@ -427,11 +503,81 @@ export function populateLists(meta, dependencies = {}) {
     });
 
   const sheetsCleanup = createVirtualList(sheetsList, worksheetData, (item) =>
-    createListItem(item.name, item.nodeId, dependencies)
+    createToggleItem(item.name, item.nodeId)
   );
   state.virtualLists.set('sheets', sheetsCleanup);
+  setCount('sheets-count', worksheetData.length);
 
-  // Populate search datalist
+  // ── Calculations (multi-select) ──────────────────────────────────────────
+
+  if (calcsList) {
+    const calcData = (state.graph?.nodes || [])
+      .filter((n) => n && n.type === 'CalculatedField')
+      .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+      .map((n) => ({ name: n.name || n.id, nodeId: n.id }));
+
+    const calcsCleanup = createVirtualList(calcsList, calcData, (item) =>
+      createToggleItem(item.name, item.nodeId)
+    );
+    state.virtualLists.set('calcs', calcsCleanup);
+    setCount('calcs-count', calcData.length);
+  }
+
+  // ── Parameters (multi-select) ────────────────────────────────────────────
+
+  if (paramsList) {
+    const paramData = (state.graph?.nodes || [])
+      .filter((n) => n && n.type === 'Parameter')
+      .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+      .map((n) => ({ name: n.name || n.id, nodeId: n.id }));
+
+    const paramsCleanup = createVirtualList(paramsList, paramData, (item) =>
+      createToggleItem(item.name, item.nodeId)
+    );
+    state.virtualLists.set('params', paramsCleanup);
+    setCount('params-count', paramData.length);
+  }
+
+  // ── Relationships (multi-select edges) ───────────────────────────────────
+
+  if (relationshipsList) {
+    const relData = (state.graph?.edges || [])
+      .filter((e) => e && e.source && e.target)
+      .map((e) => {
+        const srcName = state.idToName.get(e.source) || displayName(e.source) || e.source;
+        const tgtName = state.idToName.get(e.target) || displayName(e.target) || e.target;
+        return {
+          label: `${srcName} → ${tgtName}`,
+          tooltip: e.rel ? `${srcName} → ${tgtName} (${e.rel})` : `${srcName} → ${tgtName}`,
+          sourceId: e.source,
+          targetId: e.target,
+        };
+      });
+
+    const relCleanup = createVirtualList(relationshipsList, relData, (item) => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = item.label;
+      button.title = item.tooltip;
+      button.className = 'sidebar-item-btn sidebar-item-rel';
+      button.dataset.sourceId = item.sourceId;
+      button.dataset.targetId = item.targetId;
+      button.addEventListener('click', () => {
+        const wasActive = button.classList.contains('active');
+        button.classList.toggle('active', !wasActive);
+        button.setAttribute('aria-pressed', wasActive ? 'false' : 'true');
+        onSelectionChange();
+      });
+      li.appendChild(button);
+      return li;
+    });
+    state.virtualLists.set('relationships', relCleanup);
+    setCount('relationships-count', relData.length);
+  }
+
+  // ── Search datalist ──────────────────────────────────────────────────────
+
   const seenValues = new Set();
   (state.graph?.nodes || []).forEach((node) => {
     if (node && node.name && !seenValues.has(node.name)) {
@@ -442,5 +588,9 @@ export function populateLists(meta, dependencies = {}) {
     }
   });
 
-  logger.info('[populateLists]', `Listed ${dashboardData.length} dashboards, ${worksheetData.length} sheets`);
+  logger.info(
+    '[populateLists]',
+    `Listed ${dashboardData.length} dashboards, ${worksheetData.length} sheets,`,
+    `${calcsList?.children.length ?? 0} calcs, ${paramsList?.children.length ?? 0} params`
+  );
 }

--- a/src/ui-handlers.js
+++ b/src/ui-handlers.js
@@ -20,7 +20,7 @@ import { parseTwbx, parseTwb, parseTwbText } from './parsers.js';
 import { buildGraph, normalizeGraph, syncGraphLookups } from './graph-builder.js';
 import { applyCyTheme } from './cytoscape-config.js';
 import { setLayoutButton } from './layouts.js';
-import { applyFilters, fitAll, focusOnNode, filterByDashboard, clearDashboardFilter } from './filters.js';
+import { applyFilters, fitAll, focusOnNode, filterByDashboard, clearDashboardFilter, filterBySidebarSelection } from './filters.js';
 import { renderDetails, syncListSelection, populateLists } from './rendering.js';
 
 /**
@@ -356,6 +356,7 @@ export async function handleFiles(fileList) {
       focusOnNode: (id, opts) => focusOnNode(id, opts, { renderDetails, syncListSelection }),
       filterByDashboard,
       clearDashboardFilter,
+      filterBySidebarSelection,
     });
     drawGraph(graph);
     fitAll();

--- a/styles.css
+++ b/styles.css
@@ -566,38 +566,144 @@ summary::-webkit-details-marker {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Sidebar section labels and dashboard filter list                           */
+/* Sidebar collapsible groups (details/summary)                               */
 /* -------------------------------------------------------------------------- */
 
-.sidebar-section {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.sidebar-group {
+  border: 1px solid var(--gem-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
-.sidebar-label {
+/* Override the global summary pill style for sidebar groups */
+.sidebar-group > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--gem-muted);
-  margin: 0;
+  background: var(--gem-surface-2);
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  width: 100%;
+  cursor: pointer;
+  transition: color var(--trans), background var(--trans);
+}
+
+.sidebar-group > summary::after {
+  content: '›';
+  font-size: 1rem;
+  margin-left: auto;
+  display: inline-block;
+  transform: rotate(0deg);
+  transition: transform var(--trans);
+  color: var(--gem-muted);
+}
+
+.sidebar-group[open] > summary::after {
+  transform: rotate(90deg);
+}
+
+.sidebar-group > summary:hover {
+  color: var(--gem-text);
+  background: rgba(139, 92, 246, 0.06);
+  box-shadow: none;
+  transform: none;
+}
+
+.sidebar-group > summary:focus-visible {
+  outline: 2px solid var(--gem-primary);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.sidebar-group-body {
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .sidebar-hint {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--gem-muted);
   opacity: 0.7;
-  margin: 0;
+  margin: 2px 4px 2px;
+  padding: 0;
 }
 
-.sidebar-section ul {
+.sidebar-group ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.sidebar-count {
+  background: var(--gem-surface);
+  border: 1px solid var(--gem-border);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: var(--gem-muted);
+  min-width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+/* Toggle-able sidebar item buttons (multi-select) */
+.sidebar-item-btn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: var(--gem-text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background var(--trans), border-color var(--trans);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-item-btn:hover {
+  background: rgba(139, 92, 246, 0.08);
+  border-color: transparent;
+}
+
+.sidebar-item-btn.active {
+  background: linear-gradient(180deg, rgba(139, 92, 246, 0.22), rgba(139, 92, 246, 0.09));
+  border-color: rgba(139, 92, 246, 0.45);
+  color: var(--gem-text);
+}
+
+.sidebar-item-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--gem-glow);
+}
+
+/* Relationship items show arrows, slightly smaller text */
+.sidebar-item-rel {
+  font-size: 0.78rem;
+  color: var(--gem-muted);
+}
+
+.sidebar-item-rel:hover,
+.sidebar-item-rel.active {
+  color: var(--gem-text);
 }
 
 .dashboard-filter-btn {


### PR DESCRIPTION
…culations, Parameters, Relationships

- Replace flat sidebar lists with collapsible <details> sections for all 4 categories
- Dashboards retains existing single-select graph filter behaviour
- Sheets, Calculations, Parameters: toggleable items that filter graph to show selected nodes + neighbours
- Relationships: lists graph edges as "Source → Target" with same multi-select filtering
- Count badges on each section header show how many items are loaded
- Added filterBySidebarSelection() to filters.js for union-neighbourhood filtering
- CSS: sidebar-group, sidebar-count, sidebar-item-btn styles with active/hover states

